### PR TITLE
Fixed blank window from race condition in typewriter demo

### DIFF
--- a/examples/typewriter.rs
+++ b/examples/typewriter.rs
@@ -40,7 +40,7 @@ pub fn main() {
         .add_plugins(MaterialPlugin::<ExtendedMaterial<StandardMaterial, TypewriterShader>>::default())
         .add_plugins(Text3dPlugin {
             load_system_fonts: true,
-            asynchronous_load: true,
+            asynchronous_load: false,
             ..Default::default()
         })
         .insert_resource(AmbientLight {


### PR DESCRIPTION
This fixes inconsistent runtime behavior from the `typewriter.rs` example, which sometimes displays only an empty gray window and no text. 

On a Windows PC, `cargo run --example typewriter` (or `typewriter.exe`) displays no text on many two thirds of runs, just an empty dark gray window, but runs successfully as expected sometimes. On Linux, it always shows just the empty gray window with no text for me. The console output produced by the program shows no errors and is the same on both good and bad runs.

Setting `asynchronous_load` to `false` fixes the issue, and the text appears as expected on both platforms. (Removing the line would also work, as it defaults to false). It seems with `asynchronous_load: true`, if the font isn't loaded in time for the first frame then the text is never rendered, so it's a kind of race condition.

Background: I'm pretty new to Rust and Bevy. **bevy_rich_text3d** seems like a very useful crate and does a lot of what I was looking for, but the typewriter example only seemed to work sometimes for me.

I'll leave it to the maintainers to work out if this is a deeper issue or just a problem with the typewriter example. I haven't dug into the source code enough to be sure why it only seems to affect `typewriter` but not the `multifont` example, which also uses `asynchronous_load`.

Cheers. Thanks for creating and maintaining this.