### PR TITLE
Reflect Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,19 @@ Mesh based raster rich text implementation for bevy.
 keywords = ["bevy", "text", "font"]
 
 [features]
-default = ["2d", "3d"]
+default = ["2d", "3d", "reflect"]
 2d = ["bevy/bevy_sprite"]
 3d = ["bevy/bevy_pbr"]
+reflect = []
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = ["bevy_log", "bevy_image", "bevy_render", "bevy_asset", "bevy_window"] }
+bevy = { version = "0.16", default-features = false, features = [
+  "bevy_log",
+  "bevy_image",
+  "bevy_render",
+  "bevy_asset",
+  "bevy_window",
+] }
 cosmic-text = "0.14.2"
 rustc-hash = "2.1.1"
 sys-locale = "0.3.2"
@@ -33,5 +40,5 @@ opt-level = 3
 opt-level = 3
 
 [dev-dependencies]
-bevy = "0.16.0"
+bevy = "0.16"
 fastrand = "2.3.0"

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -6,6 +6,7 @@ use bevy::{
     color::{Color, Srgba},
     math::Vec3,
     pbr::{AmbientLight, MeshMaterial3d, StandardMaterial},
+    platform::collections::HashMap,
     prelude::{
         AlphaMode, Camera3d, Commands, Component, Entity, Local, Mesh3d, OrthographicProjection,
         Projection, Query, Res, ResMut, Resource, Transform,
@@ -17,7 +18,6 @@ use bevy_rich_text3d::{
     ParseError, Text3d, Text3dBounds, Text3dPlugin, Text3dSegment, Text3dStyling, TextAlign,
     TextAnchor, TextAtlas, TextFetch,
 };
-use rustc_hash::FxHashMap;
 
 #[derive(Debug, Component)]
 pub struct Unit(&'static str);
@@ -47,10 +47,10 @@ impl FromStr for Stat {
 }
 
 #[derive(Debug, Component)]
-pub struct StatMap(FxHashMap<Stat, i32>);
+pub struct StatMap(HashMap<Stat, i32>);
 
 #[derive(Debug, Resource)]
-pub struct NameToUnit(FxHashMap<String, Entity>);
+pub struct NameToUnit(HashMap<String, Entity>);
 
 pub fn main() {
     let mut app = App::new();
@@ -66,7 +66,7 @@ pub fn main() {
         });
     app.world_mut().spawn((
         Unit("Samuel"),
-        StatMap(FxHashMap::from_iter([
+        StatMap(HashMap::from_iter([
             (Stat::Strength, 1),
             (Stat::Intellect, 2),
             (Stat::Agility, 3),
@@ -76,7 +76,7 @@ pub fn main() {
     ));
     app.world_mut().spawn((
         Unit("Catalina"),
-        StatMap(FxHashMap::from_iter([
+        StatMap(HashMap::from_iter([
             (Stat::Strength, 5),
             (Stat::Intellect, 5),
             (Stat::Agility, 5),
@@ -86,7 +86,7 @@ pub fn main() {
     ));
     app.world_mut().spawn((
         Unit("Rufus"),
-        StatMap(FxHashMap::from_iter([
+        StatMap(HashMap::from_iter([
             (Stat::Strength, 5),
             (Stat::Intellect, 5),
             (Stat::Agility, 5),

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -1,12 +1,11 @@
 use std::str::FromStr;
-
+use rustc_hash::FxHashMap;
 use bevy::{
     app::{App, PostStartup, Startup, Update},
     asset::Assets,
     color::{Color, Srgba},
     math::Vec3,
     pbr::{AmbientLight, MeshMaterial3d, StandardMaterial},
-    platform::collections::HashMap,
     prelude::{
         AlphaMode, Camera3d, Commands, Component, Entity, Local, Mesh3d, OrthographicProjection,
         Projection, Query, Res, ResMut, Resource, Transform,
@@ -47,10 +46,10 @@ impl FromStr for Stat {
 }
 
 #[derive(Debug, Component)]
-pub struct StatMap(HashMap<Stat, i32>);
+pub struct StatMap(FxHashMap<Stat, i32>);
 
 #[derive(Debug, Resource)]
-pub struct NameToUnit(HashMap<String, Entity>);
+pub struct NameToUnit(FxHashMap<String, Entity>);
 
 pub fn main() {
     let mut app = App::new();
@@ -66,7 +65,7 @@ pub fn main() {
         });
     app.world_mut().spawn((
         Unit("Samuel"),
-        StatMap(HashMap::from_iter([
+        StatMap(FxHashMap::from_iter([
             (Stat::Strength, 1),
             (Stat::Intellect, 2),
             (Stat::Agility, 3),
@@ -76,7 +75,7 @@ pub fn main() {
     ));
     app.world_mut().spawn((
         Unit("Catalina"),
-        StatMap(HashMap::from_iter([
+        StatMap(FxHashMap::from_iter([
             (Stat::Strength, 5),
             (Stat::Intellect, 5),
             (Stat::Agility, 5),
@@ -86,7 +85,7 @@ pub fn main() {
     ));
     app.world_mut().spawn((
         Unit("Rufus"),
-        StatMap(HashMap::from_iter([
+        StatMap(FxHashMap::from_iter([
             (Stat::Strength, 5),
             (Stat::Intellect, 5),
             (Stat::Agility, 5),

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -3,17 +3,22 @@ use bevy::{
     ecs::component::Component,
     image::Image,
     math::{IVec2, Rect, Vec2},
-    reflect::TypePath,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
 };
 use rustc_hash::FxHashMap;
 
 use crate::styling::GlyphEntry;
 
+#[cfg(feature = "reflect")]
+use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
+
 /// Backing image handle and atlas of [`Text3d`].
-#[derive(Debug, Clone, Default, TypePath, Asset)]
+#[derive(Debug, Clone, Default, Asset)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(not(feature = "reflect"), derive(TypePath))]
 pub struct TextAtlas {
     pub(crate) image: Handle<Image>,
+    #[reflect(ignore)] // TODO
     pub(crate) glyphs: FxHashMap<GlyphEntry, (Rect, Vec2)>,
     pub(crate) pointer: IVec2,
     pub(crate) descent: usize,
@@ -128,4 +133,6 @@ impl TextAtlas {
 /// will use the shared [`TextAtlas::DEFAULT_IMAGE`] as
 /// the underlying image.
 #[derive(Debug, Clone, Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct TextAtlasHandle(pub Handle<TextAtlas>);

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -4,8 +4,8 @@ use bevy::{
     image::Image,
     math::{IVec2, Rect, Vec2},
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    platform::collections::HashMap,
 };
-use rustc_hash::FxHashMap;
 
 use crate::styling::GlyphEntry;
 
@@ -18,8 +18,7 @@ use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 #[cfg_attr(not(feature = "reflect"), derive(TypePath))]
 pub struct TextAtlas {
     pub(crate) image: Handle<Image>,
-    #[reflect(ignore)] // TODO
-    pub(crate) glyphs: FxHashMap<GlyphEntry, (Rect, Vec2)>,
+    pub(crate) glyphs: HashMap<GlyphEntry, (Rect, Vec2)>,
     pub(crate) pointer: IVec2,
     pub(crate) descent: usize,
 }

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -3,8 +3,8 @@ use bevy::{
     ecs::component::Component,
     image::Image,
     math::{IVec2, Rect, Vec2},
-    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
     platform::collections::HashMap,
+    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
 };
 
 use crate::styling::GlyphEntry;

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -15,7 +15,7 @@ use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 /// Backing image handle and atlas of [`Text3d`].
 #[derive(Debug, Clone, Default, Asset)]
 #[cfg_attr(feature = "reflect", derive(Reflect))]
-#[cfg_attr(not(feature = "reflect"), derive(TypePath))]
+#[cfg_attr(not(feature = "reflect"), derive(bevy::reflect::TypePath))]
 pub struct TextAtlas {
     pub(crate) image: Handle<Image>,
     pub(crate) glyphs: HashMap<GlyphEntry, (Rect, Vec2)>,

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -3,9 +3,9 @@ use bevy::{
     ecs::component::Component,
     image::Image,
     math::{IVec2, Rect, Vec2},
-    platform::collections::HashMap,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
 };
+use rustc_hash::FxHashMap;
 
 use crate::styling::GlyphEntry;
 
@@ -18,7 +18,8 @@ use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 #[cfg_attr(not(feature = "reflect"), derive(bevy::reflect::TypePath))]
 pub struct TextAtlas {
     pub(crate) image: Handle<Image>,
-    pub(crate) glyphs: HashMap<GlyphEntry, (Rect, Vec2)>,
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
+    pub(crate) glyphs: FxHashMap<GlyphEntry, (Rect, Vec2)>,
     pub(crate) pointer: IVec2,
     pub(crate) descent: usize,
 }

--- a/src/change_detection.rs
+++ b/src/change_detection.rs
@@ -13,8 +13,12 @@ use bevy::sprite::{Material2d, MeshMaterial2d};
 use bevy::{
     app::{Plugin, PostUpdate},
     asset::Assets,
-    prelude::IntoScheduleConfigs,
-    prelude::{Changed, Query, ResMut, SystemSet},
+    ecs::{
+        change_detection::ResMut,
+        query::Changed,
+        schedule::{IntoScheduleConfigs, SystemSet},
+        system::Query,
+    },
 };
 
 use crate::Text3dDimensionOut;
@@ -47,7 +51,7 @@ macro_rules! impl_mat {
         }
 
         impl<T: $ty> Plugin for $name<T> {
-            fn build(&self, app: &mut bevy::prelude::App) {
+            fn build(&self, app: &mut bevy::app::App) {
                 app.add_systems(PostUpdate, $f::<T>.in_set(TouchMaterialSet));
             }
         }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,8 +1,12 @@
 use std::str::FromStr;
 
-use bevy::{
-    ecs::world::Mut,
-    prelude::{Component, DetectChanges, Entity, EntityRef, Query, Without},
+use bevy::ecs::{
+    change_detection::DetectChanges,
+    component::Component,
+    entity::Entity,
+    query::Without,
+    system::Query,
+    world::{EntityRef, Mut},
 };
 
 /// Prevent [`Text3d`](crate::Text3d) from despawning a [`FetchedTextSegment`] on remove.

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -8,9 +8,13 @@ use bevy::ecs::{
     system::Query,
     world::{EntityRef, Mut},
 };
+#[cfg(feature = "reflect")]
+use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 
 /// Prevent [`Text3d`](crate::Text3d) from despawning a [`FetchedTextSegment`] on remove.
 #[derive(Debug, Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct SharedTextSegment;
 
 /// A string segment on a component, as opposed to in a [`Text3d`](crate::Text3d).
@@ -18,6 +22,8 @@ pub struct SharedTextSegment;
 /// By default [`Text3d`](crate::Text3d) removes all [`FetchedTextSegment`] on remove,
 /// add [`SharedTextSegment`] to prevent this behavior.
 #[derive(Debug, Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct FetchedTextSegment(pub String);
 
 impl FetchedTextSegment {
@@ -48,6 +54,8 @@ impl FetchedTextSegment {
 /// A component that fetches data as a string from the world.
 #[derive(Component)]
 #[require(FetchedTextSegment)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct TextFetch {
     entity: Entity,
     fetch: Box<dyn FnMut(EntityRef) -> Option<String> + Send + Sync>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,13 @@ use bevy::{
     asset::{AssetApp, AssetId, Assets},
     ecs::{
         query::With,
-        schedule::{common_conditions::resource_exists, IntoScheduleConfigs},
+        resource::Resource,
+        schedule::{common_conditions::resource_exists, IntoScheduleConfigs, SystemSet},
         system::{Query, ResMut},
         world::Ref,
     },
     image::Image,
-    prelude::{Resource, SystemSet, TransformSystem},
+    transform::TransformSystem,
     window::{PrimaryWindow, Window},
 };
 use change_detection::TouchMaterialSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,6 @@ pub use parse::ParseError;
 pub use styling::{SegmentStyle, Text3dStyling};
 pub use text3d::{Text3d, Text3dSegment};
 
-use crate::styling::GlyphEntry;
-
 fn synchronize_scale_factor(
     mut settings: ResMut<Text3dPlugin>,
     main_window: Query<Ref<Window>, With<PrimaryWindow>>,
@@ -146,7 +144,7 @@ impl Plugin for Text3dPlugin {
             .register_type::<TextStyle>()
             .register_type::<Text3dSegment>()
             .register_type::<SegmentStyle>()
-            .register_type::<GlyphEntry>()
+            .register_type::<crate::styling::GlyphEntry>()
             .register_type::<SharedTextSegment>()
             .register_type::<FetchedTextSegment>()
             .register_type::<TextAlign>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,8 @@ impl Plugin for Text3dPlugin {
         #[cfg(feature = "reflect")]
         app.register_type::<Text3d>()
             .register_type::<Text3dStyling>()
+            .register_type::<TextWeight>()
+            .register_type::<TextStyle>()
             .register_type::<Text3dSegment>()
             .register_type::<SegmentStyle>()
             .register_type::<GlyphEntry>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ pub use parse::ParseError;
 pub use styling::{SegmentStyle, Text3dStyling};
 pub use text3d::{Text3d, Text3dSegment};
 
+use crate::styling::GlyphEntry;
+
 fn synchronize_scale_factor(
     mut settings: ResMut<Text3dPlugin>,
     main_window: Query<Ref<Window>, With<PrimaryWindow>>,
@@ -112,7 +114,7 @@ pub struct LoadFonts {
     /// Path of font directories to be loaded.
     pub font_directories: Vec<String>,
     /// Fonts embedded in the executable.
-    #[reflect(ignore)] // TODO
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub font_embedded: Vec<&'static [u8]>,
 }
 
@@ -137,6 +139,21 @@ pub struct Text3dSet;
 
 impl Plugin for Text3dPlugin {
     fn build(&self, app: &mut App) {
+        #[cfg(feature = "reflect")]
+        app.register_type::<Text3d>()
+            .register_type::<Text3dStyling>()
+            .register_type::<Text3dSegment>()
+            .register_type::<SegmentStyle>()
+            .register_type::<GlyphEntry>()
+            .register_type::<SharedTextSegment>()
+            .register_type::<FetchedTextSegment>()
+            .register_type::<TextAlign>()
+            .register_type::<GlyphMeta>()
+            .register_type::<Text3dBounds>()
+            .register_type::<TextAnchor>()
+            .register_type::<Text3dDimensionOut>()
+            .register_type::<LoadFonts>();
+
         app.init_asset::<TextAtlas>();
         app.init_resource::<LoadFonts>();
         app.insert_resource::<Text3dPlugin>(self.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ use bevy::{
     transform::TransformSystem,
     window::{PrimaryWindow, Window},
 };
+#[cfg(feature = "reflect")]
+use bevy::{ecs::reflect::ReflectResource, reflect::Reflect};
+
 use change_detection::TouchMaterialSet;
 #[cfg(feature = "2d")]
 pub use change_detection::TouchTextMaterial2dPlugin;
@@ -62,6 +65,8 @@ fn synchronize_scale_factor(
 
 /// Text3d Plugin, add [`Text3dPluginSettings`] before this to modify its behavior.
 #[derive(Debug, Resource, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Resource))]
 pub struct Text3dPlugin {
     /// Size of the default font atlas, by default `(512, 512)`, we only extend the atlas by doubling in size vertically.
     ///
@@ -99,12 +104,15 @@ pub struct Text3dPlugin {
 ///
 /// This can be modified before startup in other plugins.
 #[derive(Debug, Resource, Default, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Resource))]
 pub struct LoadFonts {
     /// Path of fonts to be loaded.
     pub font_paths: Vec<String>,
     /// Path of font directories to be loaded.
     pub font_directories: Vec<String>,
     /// Fonts embedded in the executable.
+    #[reflect(ignore)] // TODO
     pub font_embedded: Vec<&'static [u8]>,
 }
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,9 +1,9 @@
-use std::ops::{Deref, DerefMut};
-
 use bevy::{
     ecs::component::Component,
     math::{IVec2, Vec2},
 };
+use cosmic_text::{Style, Weight};
+use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "reflect")]
 use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
@@ -106,4 +106,88 @@ pub struct Text3dDimensionOut {
     /// Returns `aabb`'s x and y derived from font's line height.
     pub dimension: Vec2,
     pub(crate) atlas_dimension: IVec2,
+}
+
+/// Allows italic or oblique faces to be selected.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+pub enum TextStyle {
+    /// A face that is neither italic not obliqued.
+    Normal,
+    /// A form that is generally cursive in nature.
+    Italic,
+    /// A typically-sloped version of the regular face.
+    Oblique,
+}
+
+impl Default for TextStyle {
+    #[inline]
+    fn default() -> TextStyle {
+        TextStyle::Normal
+    }
+}
+
+impl Into<Style> for TextStyle {
+    fn into(self) -> Style {
+        match self {
+            TextStyle::Normal => Style::Normal,
+            TextStyle::Italic => Style::Italic,
+            TextStyle::Oblique => Style::Oblique,
+        }
+    }
+}
+
+impl Into<TextStyle> for Style {
+    fn into(self) -> TextStyle {
+        match self {
+            Style::Normal => TextStyle::Normal,
+            Style::Italic => TextStyle::Italic,
+            Style::Oblique => TextStyle::Oblique,
+        }
+    }
+}
+
+/// Specifies the weight of glyphs in the font, their degree of blackness or stroke thickness.
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+pub struct TextWeight(pub u16);
+
+impl Default for TextWeight {
+    #[inline]
+    fn default() -> TextWeight {
+        TextWeight::NORMAL
+    }
+}
+
+impl TextWeight {
+    /// Thin weight (100), the thinnest value.
+    pub const THIN: TextWeight = TextWeight(Weight::THIN.0);
+    /// Extra light weight (200).
+    pub const EXTRA_LIGHT: TextWeight = TextWeight(Weight::EXTRA_LIGHT.0);
+    /// Light weight (300).
+    pub const LIGHT: TextWeight = TextWeight(Weight::LIGHT.0);
+    /// Normal (400).
+    pub const NORMAL: TextWeight = TextWeight(Weight::NORMAL.0);
+    /// Medium weight (500, higher than normal).
+    pub const MEDIUM: TextWeight = TextWeight(Weight::MEDIUM.0);
+    /// Semibold weight (600).
+    pub const SEMIBOLD: TextWeight = TextWeight(Weight::SEMIBOLD.0);
+    /// Bold weight (700).
+    pub const BOLD: TextWeight = TextWeight(Weight::BOLD.0);
+    /// Extra-bold weight (800).
+    pub const EXTRA_BOLD: TextWeight = TextWeight(Weight::EXTRA_BOLD.0);
+    /// Black weight (900), the thickest value.
+    pub const BLACK: TextWeight = TextWeight(Weight::BLACK.0);
+}
+
+impl Into<Weight> for TextWeight {
+    fn into(self) -> Weight {
+        Weight(self.0)
+    }
+}
+
+impl Into<TextWeight> for Weight {
+    fn into(self) -> TextWeight {
+        TextWeight(self.0)
+    }
 }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,8 +1,8 @@
 use std::ops::{Deref, DerefMut};
 
 use bevy::{
+    ecs::component::Component,
     math::{IVec2, Vec2},
-    prelude::Component,
 };
 
 /// Horizontal align of text.

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -5,8 +5,12 @@ use bevy::{
     math::{IVec2, Vec2},
 };
 
+#[cfg(feature = "reflect")]
+use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
+
 /// Horizontal align of text.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub enum TextAlign {
     #[default]
     Left,
@@ -26,6 +30,7 @@ impl TextAlign {
 
 /// Determines what kind of data each field in `uv1` carry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub enum GlyphMeta {
     /// Left to right count of the glyph, `0`, `1`, etc.
     #[default]
@@ -44,6 +49,8 @@ pub enum GlyphMeta {
 
 /// Determines the maximum width of rendered text, by default infinite.
 #[derive(Debug, Component)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct Text3dBounds {
     pub width: f32,
 }
@@ -56,6 +63,7 @@ impl Default for Text3dBounds {
 
 /// Anchor of a text block, usually in `(-0.5, -0.5)..=(0.5, 0.5)`.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct TextAnchor(pub Vec2);
 
 impl Deref for TextAnchor {
@@ -92,6 +100,8 @@ impl TextAnchor {
 
 /// Size of the output mesh's `Aabb`.
 #[derive(Debug, Component, Default)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct Text3dDimensionOut {
     /// Returns `aabb`'s x and y derived from font's line height.
     pub dimension: Vec2,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -82,7 +82,7 @@ impl Text3d {
     ///
     /// Without `:` values in brackets are treated as dynamic values and passed to the `fetch_string` function.
     /// The result should either be a string fetched from the world
-    /// or an [`Entity`](bevy::prelude::Entity) with a [`FetchedTextSegment`](crate::FetchedTextSegment) component.
+    /// or an [`Entity`](bevy::ecs::entity::Entity) with a [`FetchedTextSegment`](crate::FetchedTextSegment) component.
     ///
     ///
     /// ## Markdown

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,28 +1,30 @@
 use std::{iter::repeat_n, num::NonZeroU32, str::FromStr};
 
-use cosmic_text::{Style, Weight};
-
-use crate::{color_table::parse_color, SegmentStyle, Text3d, Text3dSegment};
+use crate::{
+    color_table::parse_color,
+    misc::{TextStyle, TextWeight},
+    SegmentStyle, Text3d, Text3dSegment,
+};
 
 trait Flip {
     fn flip(&mut self);
 }
 
-impl Flip for Option<Weight> {
+impl Flip for Option<TextWeight> {
     fn flip(&mut self) {
         *self = match *self {
-            Some(w) if w <= Weight::NORMAL => Some(Weight::BOLD),
-            None => Some(Weight::BOLD),
-            _ => Some(Weight::NORMAL),
+            Some(w) if w <= TextWeight::NORMAL => Some(TextWeight::BOLD),
+            None => Some(TextWeight::BOLD),
+            _ => Some(TextWeight::NORMAL),
         }
     }
 }
 
-impl Flip for Option<Style> {
+impl Flip for Option<TextStyle> {
     fn flip(&mut self) {
         *self = match *self {
-            Some(Style::Normal) | None => Some(Style::Italic),
-            _ => Some(Style::Italic),
+            Some(TextStyle::Normal) | None => Some(TextStyle::Italic),
+            _ => Some(TextStyle::Italic),
         }
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,10 +1,14 @@
 use bevy::{
     asset::{AssetId, Assets, RenderAssetUsages},
     color::{ColorToComponents, LinearRgba},
+    ecs::{
+        change_detection::DetectChanges,
+        system::{Query, Res, ResMut},
+        world::{Mut, Ref},
+    },
     image::Image,
     math::{FloatOrd, IVec2, Rect, Vec2, Vec3, Vec4},
-    prelude::{DetectChanges, Mesh, Mesh2d, Mesh3d, Mut, Query, Ref, Res, ResMut},
-    render::mesh::{Indices, PrimitiveTopology, VertexAttributeValues},
+    render::mesh::{Indices, Mesh, Mesh2d, Mesh3d, PrimitiveTopology, VertexAttributeValues},
 };
 use cosmic_text::{
     ttf_parser::{Face, GlyphId, OutlineBuilder},

--- a/src/render.rs
+++ b/src/render.rs
@@ -193,8 +193,8 @@ pub fn text_render(
                 }),
             &Attrs::new()
                 .family(Family::Name(&styling.font))
-                .style(styling.style)
-                .weight(styling.weight),
+                .style(styling.style.into())
+                .weight(styling.weight.into()),
             Shaping::Advanced,
             None,
         );
@@ -293,7 +293,7 @@ pub fn text_render(
                                         &mut tess_commands,
                                         glyph,
                                         stroke,
-                                        attrs.weight.unwrap_or(styling.weight),
+                                        attrs.weight.unwrap_or(styling.weight).into(),
                                         face,
                                     )
                                 })
@@ -451,7 +451,7 @@ pub(crate) fn cache_glyph(
         font: glyph.font_id,
         glyph_id: glyph.glyph_id,
         size: FloatOrd(glyph.font_size),
-        weight,
+        weight: weight.into(),
         stroke,
     };
     tess_commands.commands.clear();

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -4,8 +4,13 @@ use std::{num::NonZeroU32, sync::Arc};
 
 use crate::{prepare::family, GlyphMeta, TextAlign, TextAnchor};
 
+#[cfg(feature = "reflect")]
+use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
+
 /// Default text style of a rich text component.
 #[derive(Debug, Component, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct Text3dStyling {
     /// Size of the font, corresponding to world space units.
     ///
@@ -17,8 +22,10 @@ pub struct Text3dStyling {
     /// use one of the default fonts set in `cosmic_text`.
     pub font: Arc<str>,
     /// Style of the font, i.e. italic.
+    #[reflect(ignore)] // TODO
     pub style: Style,
     /// Weight of the font, i.e. bold.
+    #[reflect(ignore)] // TODO
     pub weight: Weight,
     /// Horizontal alignment of the font.
     pub align: TextAlign,
@@ -78,13 +85,16 @@ impl Default for Text3dStyling {
 
 /// Text style of a segment.
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct SegmentStyle {
     pub font: Option<Arc<str>>,
     pub fill_color: Option<Srgba>,
     pub stroke_color: Option<Srgba>,
     pub fill: Option<bool>,
     pub stroke: Option<NonZeroU32>,
+    #[reflect(ignore)] // TODO
     pub weight: Option<Weight>,
+    #[reflect(ignore)] // TODO
     pub style: Option<Style>,
     /// Can be referenced by [`GlyphMeta::MagicNumber`].
     pub magic_number: Option<f32>,
@@ -115,10 +125,13 @@ impl SegmentStyle {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct GlyphEntry {
+    #[reflect(ignore)] // TODO
     pub font: ID,
     pub glyph_id: u16,
     pub size: FloatOrd,
+    #[reflect(ignore)] // TODO
     pub weight: Weight,
     /// If is none, render in fill mode.
     pub stroke: Option<NonZeroU32>,

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -1,4 +1,4 @@
-use bevy::{color::Srgba, math::FloatOrd, prelude::Component};
+use bevy::{color::Srgba, ecs::component::Component, math::FloatOrd};
 use cosmic_text::{fontdb::ID, Attrs, Style, Weight};
 use std::{num::NonZeroU32, sync::Arc};
 

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -127,7 +127,7 @@ impl SegmentStyle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "reflect", derive(Reflect))]
 pub struct GlyphEntry {
-    #[reflect(ignore)] // TODO
+    #[cfg_attr(feature = "reflect", reflect(ignore))]
     pub font: ID,
     pub glyph_id: u16,
     pub size: FloatOrd,

--- a/src/styling.rs
+++ b/src/styling.rs
@@ -1,11 +1,12 @@
 use bevy::{color::Srgba, ecs::component::Component, math::FloatOrd};
-use cosmic_text::{fontdb::ID, Attrs, Style, Weight};
+use cosmic_text::{fontdb::ID, Attrs};
 use std::{num::NonZeroU32, sync::Arc};
 
-use crate::{prepare::family, GlyphMeta, TextAlign, TextAnchor};
+use crate::{prepare::family, GlyphMeta, TextAlign, TextAnchor, TextStyle, TextWeight};
 
 #[cfg(feature = "reflect")]
 use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
+
 
 /// Default text style of a rich text component.
 #[derive(Debug, Component, Clone)]
@@ -22,11 +23,9 @@ pub struct Text3dStyling {
     /// use one of the default fonts set in `cosmic_text`.
     pub font: Arc<str>,
     /// Style of the font, i.e. italic.
-    #[reflect(ignore)] // TODO
-    pub style: Style,
+    pub style: TextStyle,
     /// Weight of the font, i.e. bold.
-    #[reflect(ignore)] // TODO
-    pub weight: Weight,
+    pub weight: TextWeight,
     /// Horizontal alignment of the font.
     pub align: TextAlign,
     /// Where local `[0, 0]` is inside the text block's Aabb.
@@ -92,10 +91,8 @@ pub struct SegmentStyle {
     pub stroke_color: Option<Srgba>,
     pub fill: Option<bool>,
     pub stroke: Option<NonZeroU32>,
-    #[reflect(ignore)] // TODO
-    pub weight: Option<Weight>,
-    #[reflect(ignore)] // TODO
-    pub style: Option<Style>,
+    pub weight: Option<TextWeight>,
+    pub style: Option<TextStyle>,
     /// Can be referenced by [`GlyphMeta::MagicNumber`].
     pub magic_number: Option<f32>,
 }
@@ -105,8 +102,8 @@ impl SegmentStyle {
         let family_name = self.font.as_ref().map(Arc::as_ref).unwrap_or(&base.font);
         let family = family(family_name);
         Attrs::new()
-            .weight(self.weight.unwrap_or(base.weight))
-            .style(self.style.unwrap_or(base.style))
+            .weight(self.weight.unwrap_or(base.weight).into())
+            .style(self.style.unwrap_or(base.style).into())
             .family(family)
     }
 
@@ -131,8 +128,7 @@ pub struct GlyphEntry {
     pub font: ID,
     pub glyph_id: u16,
     pub size: FloatOrd,
-    #[reflect(ignore)] // TODO
-    pub weight: Weight,
+    pub weight: TextWeight,
     /// If is none, render in fill mode.
     pub stroke: Option<NonZeroU32>,
 }

--- a/src/text3d.rs
+++ b/src/text3d.rs
@@ -3,6 +3,8 @@ use bevy::ecs::{
     entity::Entity,
     world::{DeferredWorld, Mut},
 };
+#[cfg(feature = "reflect")]
+use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 
 use crate::{
     styling::SegmentStyle, Text3dBounds, Text3dDimensionOut, Text3dStyling, TextAtlasHandle,
@@ -14,6 +16,8 @@ use crate::{
 #[derive(Debug, Component)]
 #[require(Text3dDimensionOut, Text3dBounds, TextAtlasHandle, Text3dStyling)]
 #[component(on_remove = text_3d_on_remove)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
+#[cfg_attr(feature = "reflect", reflect(Component))]
 pub struct Text3d {
     pub segments: Vec<(Text3dSegment, SegmentStyle)>,
 }
@@ -22,6 +26,7 @@ pub struct Text3d {
 ///
 /// `Extract` reads data from an entity's [`FetchedTextSegment`](crate::FetchedTextSegment) component.
 #[derive(Debug)]
+#[cfg_attr(feature = "reflect", derive(Reflect))]
 pub enum Text3dSegment {
     String(String),
     Extract(Entity),

--- a/src/text3d.rs
+++ b/src/text3d.rs
@@ -1,9 +1,7 @@
-use bevy::{
-    ecs::{
-        component::HookContext,
-        world::{DeferredWorld, Mut},
-    },
-    prelude::{Component, Entity},
+use bevy::ecs::{
+    component::{Component, HookContext},
+    entity::Entity,
+    world::{DeferredWorld, Mut},
 };
 
 use crate::{


### PR DESCRIPTION
## Details
This PR adds support for reflecting the components and most of the resources defined in this crate. The first four commits should be completely backwards compatible... but unfortunately the last commit is a breaking change for most users since it defines some wrapper types. Nearly everything, minus the last commit, is behind the new `reflect` feature.

## PR Notes
- ~~Swapped `FxHashMap` for `bevy::platform::collections::HashMap` for reflection reasons~~
- Used more direct use statements compared to importing from `bevy::prelude`
- New structs `TextWeight` and `TextStyle` that replaces `cosmic_text::Weight` and `cosmic_text::Style` respectively. I considered using `reflect_remote` here but I didn't like the resulting syntax...
- Changes bevy dependency from `0.16.0` to `0.16`

## Reasoning
- Reflecting these types enables compatibility with `bevy-inspector-egui`, which allows users to mutate the values in real time, vastly improving the developer experience

## Migration Guide:

### Using .into()
```diff
   Text3dStyling {
-      weight: Weight::EXTRA_BOLD,
+      weight: Weight::EXTRA_BOLD.into(),
-      style: Style::Italic,
+      style: Style::Italic.into(),
       ..Default::default()
   }
```

### Using the new structs
```diff
   Text3dStyling {
-      weight: Weight::EXTRA_BOLD,
+      weight: TextWeight::EXTRA_BOLD,
-      style: Style::Italic,
+      style: TextStyle::Italic,
       ..Default::default()
   }
```